### PR TITLE
Use 1.N.P toolchain syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/dfc
 
-go 1.23
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
CodeQL is unable to run scans without `go.mod` specifying the `1.N.P` syntax for the Go version:
![image](https://github.com/user-attachments/assets/fd2f6a3b-336c-4ea5-9828-d76cd47fa55a)

This PR will unblock future CodeQL scans.