### PR TITLE
More GITHUB_TOKEN permissions for OpenSSF

### DIFF
--- a/.github/chainguard/scorecard.sts.yaml
+++ b/.github/chainguard/scorecard.sts.yaml
@@ -5,5 +5,8 @@ claim_pattern:
 
 permissions:
   actions: read
+  checks: read
   contents: read
+  issues: read
+  pull_requests: read
   security_events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,9 @@ jobs:
       # Uncomment the permissions below if installing in a private repository.
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Private and internal repositories need more permissions.