### PR TITLE
Re-add octo-sts

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Octo-STS
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: chainguard-dev/dfc
+          identity: scorecard
+
       - name: "Run analysis"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
@@ -38,6 +47,8 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: SARIF file
@@ -45,6 +56,8 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The default GITHUB_TOKEN permissions are working now so we can reintroduce octo-sts.