### PR TITLE
Special support for busybox relating to useradd/groupadd and tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,29 @@ then `USER root` will be appended under the last `FROM` line.
 
 In the future we plan to handle this more elegantly, but this is the current state.
 
+## Special considerations
+
+### Busybox command syntax
+
+#### useradd/groupadd vs. adduser/addgroup
+
+Since adding users and groups in Chainguard Images in Dockerfiles requires
+`adduser` / `addgroup` (via busybox), when we detect the use of
+`useradd` or `groupadd` commands in `RUN` lines, we will automatically try to
+convert them to the equivalent `adduser` / `addgroup` commands.
+
+If we see that you have installed the `shadow` package
+(which actually provides `useradd` and `groupadd`), then we do not modify
+these commands and leave them as is.
+
+#### tar command
+
+The syntax for the `tar` command is slightly different in busybox than it is
+in the GNU version which is present by default on various distros.
+
+For that reason, we will attempt to convert `tar` commands in `RUN` lines
+using the GNU syntax to use the busybox syntax instead.
+
 ## JSON mode
 
 Get converted Dockerfile as JSON using `--json` / `-j`:

--- a/pkg/dfc/adduser.go
+++ b/pkg/dfc/adduser.go
@@ -1,0 +1,202 @@
+package dfc
+
+import (
+	"strings"
+)
+
+// ConvertUserAddToAddUser converts a useradd command to the equivalent adduser command
+func ConvertUserAddToAddUser(part *ShellPart) *ShellPart {
+	if part.Command != CommandUserAdd {
+		return part
+	}
+
+	// Create a new shell part with the same extra content and delimiter
+	result := &ShellPart{
+		ExtraPre:  part.ExtraPre,
+		Command:   CommandAddUser,
+		Delimiter: part.Delimiter,
+	}
+
+	// Process arguments
+	var resultArgs []string
+	var username string
+	var hasUsername bool
+	i := 0
+
+	// Process arguments
+	for i < len(part.Args) {
+		arg := part.Args[i]
+
+		// Look for the username (first non-option argument)
+		if !strings.HasPrefix(arg, "-") && !hasUsername {
+			username = arg
+			hasUsername = true
+			i++
+			continue
+		}
+
+		// Process options
+		switch arg {
+		// Options that are simply removed (create home is default in adduser)
+		case "-m", "--create-home":
+			i++
+			continue
+
+		// Options that are renamed
+		case "-r", "--system":
+			resultArgs = append(resultArgs, "--system")
+			i++
+
+		case "-M", "--no-create-home":
+			resultArgs = append(resultArgs, "--no-create-home")
+			i++
+
+		// Options that need arguments and are renamed
+		case "-s", "--shell":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--shell", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		case "-d", "--home-dir":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--home", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		case "-c", "--comment":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--gecos", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		case "-g", "--gid":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--ingroup", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		case "-u", "--uid":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--uid", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		// Password options converted to --disabled-password
+		case "-p", "--password":
+			resultArgs = append(resultArgs, "--disabled-password")
+			if i+1 < len(part.Args) && !strings.HasPrefix(part.Args[i+1], "-") {
+				i += 2
+			} else {
+				i++
+			}
+
+		// Options that we skip along with their arguments
+		case "-k", "--skel", "-N", "--no-user-group":
+			if i+1 < len(part.Args) && !strings.HasPrefix(part.Args[i+1], "-") {
+				i += 2
+			} else {
+				i++
+			}
+
+		// Include other parts that haven't been processed
+		default:
+			resultArgs = append(resultArgs, arg)
+			i++
+		}
+	}
+
+	// Add username at the end
+	if hasUsername {
+		resultArgs = append(resultArgs, username)
+	}
+
+	result.Args = resultArgs
+	return result
+}
+
+// ConvertGroupAddToAddGroup converts a groupadd command to the equivalent addgroup command
+func ConvertGroupAddToAddGroup(part *ShellPart) *ShellPart {
+	if part.Command != CommandGroupAdd {
+		return part
+	}
+
+	// Create a new shell part with the same extra content and delimiter
+	result := &ShellPart{
+		ExtraPre:  part.ExtraPre,
+		Command:   CommandAddGroup,
+		Delimiter: part.Delimiter,
+	}
+
+	// Process arguments
+	var resultArgs []string
+	var groupname string
+	var hasGroupname bool
+	i := 0
+
+	// Process arguments
+	for i < len(part.Args) {
+		arg := part.Args[i]
+
+		// Look for the groupname (first non-option argument)
+		if !strings.HasPrefix(arg, "-") && !hasGroupname {
+			groupname = arg
+			hasGroupname = true
+			i++
+			continue
+		}
+
+		// Process options
+		switch arg {
+		// Options that are renamed
+		case "-r", "--system":
+			resultArgs = append(resultArgs, "--system")
+			i++
+
+		// Options that need arguments and are renamed
+		case "-g", "--gid":
+			if i+1 < len(part.Args) {
+				resultArgs = append(resultArgs, "--gid", part.Args[i+1])
+				i += 2
+			} else {
+				i++
+			}
+
+		// Options that we skip (not supported in addgroup)
+		case "-f", "--force", "-o", "--non-unique":
+			i++
+			continue
+
+		// Options that we skip along with their arguments
+		case "-K", "--key", "-p", "--password":
+			if i+1 < len(part.Args) && !strings.HasPrefix(part.Args[i+1], "-") {
+				i += 2
+			} else {
+				i++
+			}
+
+		// Include other parts that haven't been processed
+		default:
+			resultArgs = append(resultArgs, arg)
+			i++
+		}
+	}
+
+	// Add groupname at the end
+	if hasGroupname {
+		resultArgs = append(resultArgs, groupname)
+	}
+
+	result.Args = resultArgs
+	return result
+}

--- a/pkg/dfc/adduser_test.go
+++ b/pkg/dfc/adduser_test.go
@@ -1,0 +1,465 @@
+package dfc
+
+import (
+	"testing"
+)
+
+func TestConvertUserAddToAddUser(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *ShellPart
+		expected *ShellPart
+	}{
+		{
+			name: "basic useradd",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"myuser"},
+			},
+		},
+		{
+			name: "create home directory",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-m", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"myuser"},
+			},
+		},
+		{
+			name: "create home directory long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--create-home", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"myuser"},
+			},
+		},
+		{
+			name: "system user",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-r", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--system", "myuser"},
+			},
+		},
+		{
+			name: "system user long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--system", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--system", "myuser"},
+			},
+		},
+		{
+			name: "custom shell",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-s", "/bin/bash", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--shell", "/bin/bash", "myuser"},
+			},
+		},
+		{
+			name: "custom shell long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--shell", "/bin/bash", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--shell", "/bin/bash", "myuser"},
+			},
+		},
+		{
+			name: "custom home directory",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-d", "/custom/home", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--home", "/custom/home", "myuser"},
+			},
+		},
+		{
+			name: "custom home directory long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--home-dir", "/custom/home", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--home", "/custom/home", "myuser"},
+			},
+		},
+		{
+			name: "with comment",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-c", "Test User", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--gecos", "Test User", "myuser"},
+			},
+		},
+		{
+			name: "with comment long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--comment", "Test User", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--gecos", "Test User", "myuser"},
+			},
+		},
+		{
+			name: "with password",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-p", "password123", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--disabled-password", "myuser"},
+			},
+		},
+		{
+			name: "with password long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--password", "password123", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--disabled-password", "myuser"},
+			},
+		},
+		{
+			name: "with primary group",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-g", "mygroup", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--ingroup", "mygroup", "myuser"},
+			},
+		},
+		{
+			name: "with primary group long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--gid", "mygroup", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--ingroup", "mygroup", "myuser"},
+			},
+		},
+		{
+			name: "with user ID",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-u", "1001", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--uid", "1001", "myuser"},
+			},
+		},
+		{
+			name: "with user ID long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--uid", "1001", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--uid", "1001", "myuser"},
+			},
+		},
+		{
+			name: "no home directory",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-M", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--no-create-home", "myuser"},
+			},
+		},
+		{
+			name: "no home directory long option",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"--no-create-home", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--no-create-home", "myuser"},
+			},
+		},
+		{
+			name: "multiple options",
+			input: &ShellPart{
+				Command: CommandUserAdd,
+				Args:    []string{"-m", "-s", "/bin/bash", "-u", "1001", "-g", "mygroup", "myuser"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddUser,
+				Args:    []string{"--shell", "/bin/bash", "--uid", "1001", "--ingroup", "mygroup", "myuser"},
+			},
+		},
+		{
+			name: "preserves extra parts",
+			input: &ShellPart{
+				ExtraPre:  "# This is a comment",
+				Command:   CommandUserAdd,
+				Args:      []string{"myuser"},
+				Delimiter: "&&",
+			},
+			expected: &ShellPart{
+				ExtraPre:  "# This is a comment",
+				Command:   CommandAddUser,
+				Args:      []string{"myuser"},
+				Delimiter: "&&",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertUserAddToAddUser(tc.input)
+
+			// Compare command
+			if result.Command != tc.expected.Command {
+				t.Errorf("Command: expected %q, got %q", tc.expected.Command, result.Command)
+			}
+
+			// Compare args
+			if len(result.Args) != len(tc.expected.Args) {
+				t.Errorf("Args length: expected %d, got %d", len(tc.expected.Args), len(result.Args))
+			} else {
+				for i, arg := range tc.expected.Args {
+					if result.Args[i] != arg {
+						t.Errorf("Arg[%d]: expected %q, got %q", i, arg, result.Args[i])
+					}
+				}
+			}
+
+			// Compare ExtraPre and Delimiter
+			if result.ExtraPre != tc.expected.ExtraPre {
+				t.Errorf("ExtraPre: expected %q, got %q", tc.expected.ExtraPre, result.ExtraPre)
+			}
+			if result.Delimiter != tc.expected.Delimiter {
+				t.Errorf("Delimiter: expected %q, got %q", tc.expected.Delimiter, result.Delimiter)
+			}
+		})
+	}
+}
+
+func TestConvertGroupAddToAddGroup(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *ShellPart
+		expected *ShellPart
+	}{
+		{
+			name: "basic groupadd",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "system group",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-r", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"--system", "mygroup"},
+			},
+		},
+		{
+			name: "system group long option",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"--system", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"--system", "mygroup"},
+			},
+		},
+		{
+			name: "custom GID",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-g", "1001", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"--gid", "1001", "mygroup"},
+			},
+		},
+		{
+			name: "custom GID long option",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"--gid", "1001", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"--gid", "1001", "mygroup"},
+			},
+		},
+		{
+			name: "with force option",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-f", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "with force option long",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"--force", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "with non-unique option",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-o", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "with non-unique option long",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"--non-unique", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "with password option",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-p", "password123", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "with password option long",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"--password", "password123", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"mygroup"},
+			},
+		},
+		{
+			name: "multiple options",
+			input: &ShellPart{
+				Command: CommandGroupAdd,
+				Args:    []string{"-r", "-g", "1001", "mygroup"},
+			},
+			expected: &ShellPart{
+				Command: CommandAddGroup,
+				Args:    []string{"--system", "--gid", "1001", "mygroup"},
+			},
+		},
+		{
+			name: "preserves extra parts",
+			input: &ShellPart{
+				ExtraPre:  "# This is a comment",
+				Command:   CommandGroupAdd,
+				Args:      []string{"mygroup"},
+				Delimiter: "&&",
+			},
+			expected: &ShellPart{
+				ExtraPre:  "# This is a comment",
+				Command:   CommandAddGroup,
+				Args:      []string{"mygroup"},
+				Delimiter: "&&",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertGroupAddToAddGroup(tc.input)
+
+			// Compare command
+			if result.Command != tc.expected.Command {
+				t.Errorf("Command: expected %q, got %q", tc.expected.Command, result.Command)
+			}
+
+			// Compare args
+			if len(result.Args) != len(tc.expected.Args) {
+				t.Errorf("Args length: expected %d, got %d", len(tc.expected.Args), len(result.Args))
+			} else {
+				for i, arg := range tc.expected.Args {
+					if result.Args[i] != arg {
+						t.Errorf("Arg[%d]: expected %q, got %q", i, arg, result.Args[i])
+					}
+				}
+			}
+
+			// Compare ExtraPre and Delimiter
+			if result.ExtraPre != tc.expected.ExtraPre {
+				t.Errorf("ExtraPre: expected %q, got %q", tc.expected.ExtraPre, result.ExtraPre)
+			}
+			if result.Delimiter != tc.expected.Delimiter {
+				t.Errorf("Delimiter: expected %q, got %q", tc.expected.Delimiter, result.Delimiter)
+			}
+		})
+	}
+}

--- a/pkg/dfc/tar.go
+++ b/pkg/dfc/tar.go
@@ -1,0 +1,155 @@
+package dfc
+
+import (
+	"strings"
+)
+
+// Command constants for tar commands
+const (
+	CommandGNUTar     = "tar"
+	CommandBusyBoxTar = "tar"
+)
+
+// ConvertGNUTarToBusyboxTar converts a GNU tar command to the equivalent BusyBox tar command
+// BusyBox tar has fewer options and some different syntax compared to GNU tar
+func ConvertGNUTarToBusyboxTar(part *ShellPart) *ShellPart {
+	if part.Command != CommandGNUTar {
+		return part
+	}
+
+	// Create a new shell part with the same extra content and delimiter
+	result := &ShellPart{
+		ExtraPre:  part.ExtraPre,
+		Command:   CommandBusyBoxTar,
+		Delimiter: part.Delimiter,
+	}
+
+	// We'll use separate slices for options, files, and file option
+	var options []string
+	var files []string
+	var hasFile bool
+	var filename string
+
+	i := 0
+
+	// First pass to check for common options and gather information
+	for i < len(part.Args) {
+		arg := part.Args[i]
+
+		// Handle the main operation flags (first argument usually)
+		if i == 0 && !strings.HasPrefix(arg, "-") && len(arg) > 0 {
+			// Convert combined options like "xvf" to individual options
+			for _, c := range arg {
+				switch c {
+				case 'x':
+					options = append(options, "-x")
+				case 'c':
+					options = append(options, "-c")
+				case 'v':
+					options = append(options, "-v")
+				case 'f':
+					hasFile = true
+					// Skip adding -f here, we'll add it with the filename
+					if i+1 < len(part.Args) {
+						filename = part.Args[i+1]
+						i++
+					}
+				case 'z':
+					options = append(options, "-z")
+				case 'j':
+					options = append(options, "-j")
+				default:
+					// Pass through other single-letter options
+					options = append(options, "-"+string(c))
+				}
+			}
+			i++
+			continue
+		}
+
+		// Handle --file=value format
+		if strings.HasPrefix(arg, "--file=") {
+			hasFile = true
+			filename = arg[7:] // Extract part after --file=
+			i++
+			continue
+		}
+
+		// Handle long options and their short equivalents
+		switch arg {
+		// Extract operations
+		case "--extract", "-x":
+			options = append(options, "-x")
+
+		// Create operations
+		case "--create", "-c":
+			options = append(options, "-c")
+
+		// Verbose output
+		case "--verbose", "-v":
+			options = append(options, "-v")
+
+		// File specification
+		case "--file", "-f":
+			hasFile = true
+			if i+1 < len(part.Args) {
+				filename = part.Args[i+1]
+				i += 2
+				continue
+			}
+
+		// Compress with gzip
+		case "--gzip", "--gunzip", "-z":
+			options = append(options, "-z")
+
+		// Compress with bzip2
+		case "--bzip2", "-j":
+			options = append(options, "-j")
+
+		// Change directory
+		case "--directory", "-C":
+			if i+1 < len(part.Args) {
+				options = append(options, "-C", part.Args[i+1])
+				i += 2
+				continue
+			}
+
+		// Handle unsupported or ignored GNU tar options
+		case "--same-owner", "--preserve-permissions", "--preserve-order",
+			"--preserve", "--same-permissions", "--numeric-owner",
+			"--overwrite", "--remove-files", "--ignore-failed-read":
+			// These options are either default or not needed in BusyBox tar
+			i++
+			continue
+
+		default:
+			// Check if it's a long option we need to skip
+			if strings.HasPrefix(arg, "--") {
+				// Skip unknown long options
+				i++
+				continue
+			}
+
+			// If it doesn't start with -, it's probably a file or directory
+			files = append(files, arg)
+		}
+		i++
+	}
+
+	// Build the final args in the correct order
+	var resultArgs []string
+
+	// First add all the options
+	resultArgs = append(resultArgs, options...)
+
+	// Then add the files list
+	resultArgs = append(resultArgs, files...)
+
+	// Finally add the file option at the end if present
+	if hasFile && filename != "" {
+		resultArgs = append(resultArgs, "-f", filename)
+	}
+
+	result.Args = resultArgs
+	return result
+}

--- a/pkg/dfc/tar_test.go
+++ b/pkg/dfc/tar_test.go
@@ -1,0 +1,193 @@
+package dfc
+
+import (
+	"testing"
+)
+
+func TestConvertGNUTarToBusyboxTar(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *ShellPart
+		expected *ShellPart
+	}{
+		{
+			name: "basic extract tar with short options",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"xf", "archive.tar"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "create tar with verbose",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"cvf", "archive.tar", "file1", "file2"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-c", "-v", "file1", "file2", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "extract with gzip",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"xzf", "archive.tar.gz"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-z", "-f", "archive.tar.gz"},
+			},
+		},
+		{
+			name: "extract with bzip2",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"xjf", "archive.tar.bz2"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-j", "-f", "archive.tar.bz2"},
+			},
+		},
+		{
+			name: "extract to specific directory",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"xf", "archive.tar", "-C", "/tmp/extract"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-C", "/tmp/extract", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "with long options",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"--create", "--verbose", "--file=archive.tar", "file1", "file2"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-c", "-v", "file1", "file2", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "skip unsupported GNU options",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"--extract", "--file", "archive.tar", "--same-owner", "--preserve-permissions", "file1"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "file1", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "preserves extra parts",
+			input: &ShellPart{
+				ExtraPre:  "# Extract archive",
+				Command:   CommandGNUTar,
+				Args:      []string{"xf", "archive.tar"},
+				Delimiter: "&&",
+			},
+			expected: &ShellPart{
+				ExtraPre:  "# Extract archive",
+				Command:   CommandBusyBoxTar,
+				Args:      []string{"-x", "-f", "archive.tar"},
+				Delimiter: "&&",
+			},
+		},
+		{
+			name: "handles complex scenario",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"--extract", "--verbose", "--file", "archive.tar", "--directory", "/tmp", "--same-owner", "dir1", "file1"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-v", "-C", "/tmp", "dir1", "file1", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "already busybox style - extract with individual options",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"-x", "-v", "-f", "archive.tar"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-v", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "already busybox style - extract with directory option",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"-x", "-v", "-C", "/tmp", "-f", "archive.tar"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-v", "-C", "/tmp", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "already busybox style - create with individual options",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"-c", "-v", "file1", "file2", "-f", "archive.tar"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-c", "-v", "file1", "file2", "-f", "archive.tar"},
+			},
+		},
+		{
+			name: "already busybox style - extract with gzip",
+			input: &ShellPart{
+				Command: CommandGNUTar,
+				Args:    []string{"-x", "-z", "-f", "archive.tar.gz"},
+			},
+			expected: &ShellPart{
+				Command: CommandBusyBoxTar,
+				Args:    []string{"-x", "-z", "-f", "archive.tar.gz"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertGNUTarToBusyboxTar(tc.input)
+
+			// Compare command
+			if result.Command != tc.expected.Command {
+				t.Errorf("Command: expected %q, got %q", tc.expected.Command, result.Command)
+			}
+
+			// Compare args
+			if len(result.Args) != len(tc.expected.Args) {
+				t.Errorf("Args length: expected %d, got %d\nExpected: %v\nGot: %v",
+					len(tc.expected.Args), len(result.Args),
+					tc.expected.Args, result.Args)
+			} else {
+				for i, arg := range tc.expected.Args {
+					if result.Args[i] != arg {
+						t.Errorf("Arg[%d]: expected %q, got %q", i, arg, result.Args[i])
+					}
+				}
+			}
+
+			// Compare ExtraPre and Delimiter
+			if result.ExtraPre != tc.expected.ExtraPre {
+				t.Errorf("ExtraPre: expected %q, got %q", tc.expected.ExtraPre, result.ExtraPre)
+			}
+			if result.Delimiter != tc.expected.Delimiter {
+				t.Errorf("Delimiter: expected %q, got %q", tc.expected.Delimiter, result.Delimiter)
+			}
+		})
+	}
+}

--- a/testdata/gcds-hugo.after.Dockerfile
+++ b/testdata/gcds-hugo.after.Dockerfile
@@ -11,10 +11,13 @@ RUN apk add -U ca-certificates curl git make openssl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then ARCH=arm64; else ARCH=amd64; fi && \
+    if [ "$ARCH" = "aarch64" ] ; \
+    then ARCH=arm64 ; \
+    else ARCH=amd64 ; \
+    fi && \
     echo "Architecture: $ARCH" && \
     wget -O hugo_extended_${HUGO_VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${ARCH}.tar.gz && \
-    tar xf hugo_extended_${HUGO_VERSION}.tar.gz && \
+    tar -x -f hugo_extended_${HUGO_VERSION}.tar.gz && \
     mv hugo /usr/bin/hugo && \
     rm hugo_extended_${HUGO_VERSION}.tar.gz && \
     echo "Hugo ${HUGO_VERSION} installed" && \

--- a/testdata/golang-multi-stage.after.Dockerfile
+++ b/testdata/golang-multi-stage.after.Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 # Install UPX for binary compression (optional)
 RUN apk add -U wget xz
 RUN wget -P /tmp/ https://github.com/upx/upx/releases/download/v3.95/upx-3.95-amd64_linux.tar.xz
-RUN tar xvf /tmp/upx-3.95-amd64_linux.tar.xz -C /tmp
+RUN tar -x -v -C /tmp -f /tmp/upx-3.95-amd64_linux.tar.xz
 RUN mv /tmp/upx-3.95-amd64_linux/upx /usr/local/bin/upx
 
 # Compress the binary to reduce size

--- a/testdata/nodejs-ubuntu.after.Dockerfile
+++ b/testdata/nodejs-ubuntu.after.Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | \
     npm install -g npm@latest
 
 # Add a non-root user
-RUN useradd -m -s /bin/bash appuser
+RUN adduser --shell /bin/bash appuser
 WORKDIR /home/appuser/app
 RUN chown -R appuser:appuser /home/appuser
 

--- a/testdata/python-multi-stage.after.Dockerfile
+++ b/testdata/python-multi-stage.after.Dockerfile
@@ -28,7 +28,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Add non-root user
-RUN useradd --create-home appuser
+RUN adduser appuser
 USER appuser
 WORKDIR /home/appuser
 


### PR DESCRIPTION
Should resolve https://github.com/chainguard-dev/dfc/issues/29 and https://github.com/chainguard-dev/dfc/issues/27

Here is the summary (also added to readme):

### Busybox command syntax

#### useradd/groupadd vs. adduser/addgroup

Since adding users and groups in Chainguard Images in Dockerfiles requires
`adduser` / `addgroup` (via busybox), when we detect the use of
`useradd` or `groupadd` commands in `RUN` lines, we will automatically try to
convert them to the equivalent `adduser` / `addgroup` commands.

If we see that you have installed the `shadow` package
(which actually provides `useradd` and `groupadd`), then we do not modify
these commands and leave them as is.

#### tar command

The syntax for the `tar` command is slightly different in busybox than it is
in the GNU version which is present by default on various distros.

For that reason, we will attempt to convert `tar` commands in `RUN` lines
using the GNU syntax to use the busybox syntax instead.
