### PR TITLE
Add watch package mapping

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -227,6 +227,8 @@ packages:
             - s3fs-fuse
         uuid-runtime:
             - util-linux-misc
+        watch:
+            - procps
         xz-utils:
             - xz
         zlib1g-dev:


### PR DESCRIPTION
There is no `watch` package but debian will select `procps` if requested.

```
# apt-get update && apt-get install watch
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [512 B]
Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [252 kB]
Fetched 9300 kB in 3s (3412 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'procps' instead of 'watch'
```