### PR TITLE
Stop treating single pipe (|) as shell part delimiter

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -221,6 +221,12 @@ packages:
             - protobuf-c-compiler
         python3:
             - python-3
+        python3-pip:
+            - py3-pip
+        python3-virtualenv:
+            - py3-virtualenv
+        python3-wheel:
+            - py3-wheel
         python3-openssl:
             - py3-pyopenssl
         s3fs:

--- a/pkg/dfc/shell.go
+++ b/pkg/dfc/shell.go
@@ -62,8 +62,8 @@ func ParseMultilineShell(raw string) *ShellCommand {
 		return nil
 	}
 
-	// Known delimiters
-	delimiters := []string{"&&", "||", ";", "|", "&"}
+	// Known delimiters - removed pipe ("|") from the list
+	delimiters := []string{"&&", "||", ";", "&"}
 
 	var parts []*ShellPart
 	remainingCmd := strings.TrimSpace(cleaned)

--- a/pkg/dfc/shell_test.go
+++ b/pkg/dfc/shell_test.go
@@ -20,7 +20,7 @@ func TestShellParsing(t *testing.T) {
 	}
 	cases := []testCase{}
 
-	for _, delimiter := range []string{"&&", "||", ";", "|"} { // TODO: constant for these?
+	for _, delimiter := range []string{"&&", "||", ";"} { // Removed "|" from delimiters
 		cases = append(cases, testCase{
 			name:     "basic " + delimiter,
 			raw:      `echo hello ` + delimiter + ` echo world`,
@@ -221,6 +221,36 @@ func TestShellParsing(t *testing.T) {
 			},
 		})
 	}
+
+	// Add specific test case for pipe commands
+	cases = append(cases, testCase{
+		name:     "pipe-commands-as-single-command",
+		raw:      `apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install --yes`,
+		expected: `apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install --yes`,
+		wantCommand: &ShellCommand{
+			Parts: []*ShellPart{
+				{
+					Command: "apt-get",
+					Args:    []string{"-s", "dist-upgrade", "|", "grep", `"^Inst"`, "|", "grep", "-i", "securi", "|", "awk", "-F", `" "`, "{'print $2'}", "|", "xargs", "apt-get", "install", "--yes"},
+				},
+			},
+		},
+	})
+
+	// Add real-world test case for pipes.before.Dockerfile example
+	cases = append(cases, testCase{
+		name:     "real-world-pipes-example",
+		raw:      `apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install --yes`,
+		expected: `apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install --yes`,
+		wantCommand: &ShellCommand{
+			Parts: []*ShellPart{
+				{
+					Command: "apt-get",
+					Args:    []string{"-s", "dist-upgrade", "|", "grep", `"^Inst"`, "|", "grep", "-i", "securi", "|", "awk", "-F", `" "`, "{'print $2'}", "|", "xargs", "apt-get", "install", "--yes"},
+				},
+			},
+		},
+	})
 
 	cases = append(cases, testCase{
 		name: "real world - django  ",

--- a/testdata/nodejs-ubuntu.after.Dockerfile
+++ b/testdata/nodejs-ubuntu.after.Dockerfile
@@ -13,8 +13,7 @@ RUN apk add --no-cache build-base curl git gnupg python-3 wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Add Node.js repository and install
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | \
-    bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - && \
     apk add --no-cache nodejs && \
     npm install -g npm@latest
 

--- a/testdata/pipes.after.Dockerfile
+++ b/testdata/pipes.after.Dockerfile
@@ -1,0 +1,8 @@
+FROM cgr.dev/ORG/python:3.9-dev
+USER root
+
+RUN echo "STEP 1" && \
+    apk add --no-cache py3-pip py3-virtualenv python-3 && \
+    echo "STEP 2" && \
+    echo "STEP 3" && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache ~/.npm

--- a/testdata/pipes.before.Dockerfile
+++ b/testdata/pipes.before.Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9.18-slim
+
+RUN apt-get update -q -q && \
+ echo "STEP 1" && \
+ apt-get install python3 python3-pip python3-virtualenv --yes && \
+ echo "STEP 2" && \
+ apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install --yes && \
+ echo "STEP 3" && \
+ apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache ~/.npm

--- a/testdata/python-multi-stage.after.Dockerfile
+++ b/testdata/python-multi-stage.after.Dockerfile
@@ -5,7 +5,7 @@
 FROM cgr.dev/ORG/chainguard-base:latest AS builder-image
 USER root
 
-RUN apk add --no-cache build-base python3-pip python3-wheel python3.9 python3.9-dev python3.9-venv && \
+RUN apk add --no-cache build-base py3-pip py3-wheel python3.9 python3.9-dev python3.9-venv && \
     rm -rf /var/lib/apt/lists/*
 
 # create and activate virtual environment


### PR DESCRIPTION
Resolves #45 
also adds some missing python package mappings