### PR TITLE
feat: Add `RunLineConverter` option to allow custom RUN line conversion

### DIFF
--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -997,10 +997,7 @@ func processRunLineWithConverter(newLine *DockerfileLine, line *DockerfileLine, 
 			if err != nil {
 				return err
 			}
-			if custom != "" {
-				newLine.Converted = custom
-				return nil
-			}
+			newLine.Converted = custom
 		}
 		newLine.Converted = defaultConverted
 	}

--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -989,7 +989,6 @@ func processRunLineWithConverter(newLine *DockerfileLine, line *DockerfileLine, 
 			defaultConverted = DirectiveRun + " " + afterShell.String()
 		}
 
-		// If a custom RunLineConverter is provided, use it
 		if runLineConverter != nil {
 			custom, err := runLineConverter(newLine.Run, defaultConverted, line.Stage)
 			if err == nil && custom != "" {
@@ -997,7 +996,6 @@ func processRunLineWithConverter(newLine *DockerfileLine, line *DockerfileLine, 
 				return
 			}
 		}
-		// Otherwise, use the default
 		newLine.Converted = defaultConverted
 	}
 }

--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -436,16 +436,16 @@ type FromLineConverter func(from *FromDetails, converted string, stageHasRun boo
 //
 // Example usage:
 //
-//  myRunConverter := func(run *RunDetails, converted string, stage int) (string, error) {
-//      if run.Manager == "apt-get" {
-//          return "RUN echo 'apt-get is not allowed!'", nil
-//      }
-//      return converted, nil
-//  }
+//	myRunConverter := func(run *RunDetails, converted string, stage int) (string, error) {
+//	    if run.Manager == "apt-get" {
+//	        return "RUN echo 'apt-get is not allowed!'", nil
+//	    }
+//	    return converted, nil
+//	}
 //
-//  dockerFile.Convert(ctx, dfc.Options{
-//      RunLineConverter: myRunConverter,
-//  })
+//	dockerFile.Convert(ctx, dfc.Options{
+//	    RunLineConverter: myRunConverter,
+//	})
 type RunLineConverter func(run *RunDetails, converted string, stage int) (string, error)
 
 // Options defines the configuration options for the conversion

--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -998,8 +998,9 @@ func processRunLineWithConverter(newLine *DockerfileLine, line *DockerfileLine, 
 				return err
 			}
 			newLine.Converted = custom
+		} else {
+			newLine.Converted = defaultConverted
 		}
-		newLine.Converted = defaultConverted
 	}
 	return nil
 }

--- a/pkg/dfc/dfc_test.go
+++ b/pkg/dfc/dfc_test.go
@@ -1886,7 +1886,7 @@ RUN echo hello world`
 		t.Fatalf("ParseDockerfile(): %v", err)
 	}
 
-	myRunConverter := func(run *RunDetails, converted string, stage int) (string, error) {
+	myRunConverter := func(run *RunDetails, converted string, _ int) (string, error) {
 		if run.Manager == ManagerAptGet {
 			return "RUN echo 'apt-get is not allowed!'", nil
 		}
@@ -1921,7 +1921,7 @@ RUN apt-get update && apt-get install -y nano`
 		t.Fatalf("ParseDockerfile(): %v", err)
 	}
 
-	errRunConverter := func(run *RunDetails, converted string, stage int) (string, error) {
+	errRunConverter := func(_ *RunDetails, _ string, _ int) (string, error) {
 		return "", fmt.Errorf("custom run line error")
 	}
 


### PR DESCRIPTION
Fixes: #61

- Users can now provide a custom function to intercept and override the conversion of RUN lines.
- This enables advanced use cases such as enforcing policies, custom rewriting, or organization-specific logic for RUN instructions.
- Includes a unit test demonstrating how to use the new option.
