### PR TITLE
Add mapping for font-liberation

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -147,6 +147,8 @@ packages:
             - aws-cli
         build-essential:
             - build-base
+        fonts-liberation:
+            - font-liberation
         fuse:
             - fuse2
             - fuse-common


### PR DESCRIPTION
- debian: https://packages.debian.org/bookworm/fonts-liberation
- chainguard: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/font-liberation-2.1.5-r0.apk@sha1:305d365f197f056c2203c76f8acf028c92862cad/.PKGINFO