### PR TITLE
Add mapping for font-opensans

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -147,6 +147,8 @@ packages:
             - aws-cli
         build-essential:
             - build-base
+        fonts-open-sans:
+            - font-opensans
         fuse:
             - fuse2
             - fuse-common


### PR DESCRIPTION
- debian: https://packages.debian.org/bookworm/fonts-open-sans
- chainguard: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/font-opensans-0_git20210927-r0.apk@sha1:b0f393cfb1c9ab994fe82e61bf925674500e07de/.PKGINFO