### PR TITLE
Add mapping for cairo

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -166,6 +166,8 @@ packages:
             - glibc-dev
         libc6-dev:
             - glibc-dev
+        libcairo2:
+            - cairo
         libcurl4-openssl-dev:
             - curl-dev
         libgssapi-krb5-2:


### PR DESCRIPTION
debain: https://packages.debian.org/bookworm/libcairo2
chainguard: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/cairo-1.18.4-r1.apk@sha1:82d1e754da5fde93c02058b80da357452f39d255/.PKGINFO