### PR TITLE
Add mapping for cups-libs

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -166,6 +166,8 @@ packages:
             - glibc-dev
         libc6-dev:
             - glibc-dev
+        libcups2:
+            - cups-libs
         libcurl4-openssl-dev:
             - curl-dev
         libgssapi-krb5-2:


### PR DESCRIPTION
- debian: https://packages.debian.org/bookworm/libcups2
- chainguard: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/cups-libs-2.4.12-r0.apk@sha1:69443b0770ed728eb22195acdbc4512257e24dec/.PKGINFO