### PR TITLE
Add mapping for font-util

### DIFF
--- a/pkg/dfc/builtin-mappings.yaml
+++ b/pkg/dfc/builtin-mappings.yaml
@@ -238,6 +238,10 @@ packages:
             - util-linux-misc
         watch:
             - procps
+        xfonts-utils:
+            - font-util
+            - mkfontscale
+            - bdftopcf
         xz-utils:
             - xz
         zlib1g-dev:


### PR DESCRIPTION
- debian: https://packages.debian.org/bookworm/amd64/xfonts-utils/filelist
- chainguard:
    - font-util: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/font-util-1.4.1-r3.apk@sha1:36d3a004adf5827ba6adf19865b7b17d038434ce/.PKGINFO
    - mkfontscale: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/mkfontscale-1.2.3-r1.apk@sha1:f3953f5ea02c4ffc9eca9aecdb2c377155e1d336/.PKGINFO
    - bdftopcf: https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/bdftopcf-1.1.2-r2.apk@sha1:1b28e6a732b47bc9518cf88e393693f961727525/.PKGINFO