### PR TITLE
Remove package manager cache cleanup commands

### DIFF
--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -1254,7 +1254,7 @@ func convertPackageManagerCommands(shell *ShellCommand, packageMap PackageMap) (
 				apkAdded = true
 			}
 			// Skip this package manager command (don't add it to newParts)
-		} else {
+		} else if !isPackageManagerCleanupCommand(part) {
 			// This is not a package manager command, keep it
 			newPart := cloneShellPart(part)
 			newParts = append(newParts, newPart)
@@ -1442,4 +1442,21 @@ func normalizeImageName(imageRef string) string {
 	}
 
 	return imageRef
+}
+
+var packageManagerRemoveCacheArgs = [][]string{
+	{"-rf", "/var/lib/apt/lists/*"},
+	{"-rf", "/var/cache/yum/*"},
+}
+
+// isPackageManagerCleanupCommand checks if the shell command is a known package manager cleanup command.
+func isPackageManagerCleanupCommand(part *ShellPart) bool {
+	if part.Command == "rm" {
+		for _, args := range packageManagerRemoveCacheArgs {
+			if slices.Equal(part.Args, args) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/testdata/django.after.Dockerfile
+++ b/testdata/django.after.Dockerfile
@@ -12,16 +12,14 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # install deb packages
-RUN apk add --no-cache gettext git libpq make rsync && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache gettext git libpq make rsync
 
 ARG REQ_FILE=requirements/prod.txt
 
 # install python dependencies
 COPY ./requirements ./requirements
 RUN apk add --no-cache gcc glibc-dev postgresql-dev zlib-dev && \
-    python3 -m pip install --no-cache-dir -r ${REQ_FILE} && \
-    rm -rf /var/lib/apt/lists/*
+    python3 -m pip install --no-cache-dir -r ${REQ_FILE}
 
 # copy project
 COPY . .

--- a/testdata/gcds-hugo.after.Dockerfile
+++ b/testdata/gcds-hugo.after.Dockerfile
@@ -7,8 +7,7 @@ USER root
 ARG HUGO_VERSION=0.126.3
 ARG GO_VERSION=1.22.3
 
-RUN apk add --no-cache ca-certificates curl git make openssl && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl git make openssl
 
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ] ; \

--- a/testdata/nodejs-ubuntu.after.Dockerfile
+++ b/testdata/nodejs-ubuntu.after.Dockerfile
@@ -9,8 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_VERSION=16.x
 
 # Update and install dependencies
-RUN apk add --no-cache build-base curl git gnupg python-3 wget && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base curl git gnupg python-3 wget
 
 # Add Node.js repository and install
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - && \

--- a/testdata/python-multi-stage.after.Dockerfile
+++ b/testdata/python-multi-stage.after.Dockerfile
@@ -5,8 +5,7 @@
 FROM cgr.dev/ORG/chainguard-base:latest AS builder-image
 USER root
 
-RUN apk add --no-cache build-base py3-pip py3-wheel python3.9 python3.9-dev python3.9-venv && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base py3-pip py3-wheel python3.9 python3.9-dev python3.9-venv
 
 # create and activate virtual environment
 RUN python3.9 -m venv /opt/venv
@@ -18,8 +17,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 FROM cgr.dev/ORG/chainguard-base:latest AS runner-image
 USER root
-RUN apk add --no-cache python3-venv python3.9 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache python3-venv python3.9
 
 COPY --from=builder-image /opt/venv /opt/venv
 

--- a/testdata/yum-dnf-flags.before.Dockerfile
+++ b/testdata/yum-dnf-flags.before.Dockerfile
@@ -4,7 +4,8 @@ FROM fedora:30
 
 RUN yum update -y && \
     yum -y install httpd php php-cli php-common && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 
 RUN dnf update -y && \
     dnf -y install httpd php php-cli php-common && \


### PR DESCRIPTION
It is common practice for Dockerfile's to include commands to remove package manager cache files. These commands can be removed to provide a cleaner conversion result.