### PR TITLE
Add strict flag to force package mapping

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func cli() *cobra.Command {
 	cmd.Flags().BoolVar(&noBuiltInFlag, "no-builtin", false, "skip built-in package/image mappings, still apply default conversion logic")
 	cmd.Flags().Var(&level, "log-level", "log level (e.g. debug, info, warn, error)")
 	cmd.Flags().BoolVar(&strictFlag, "strict", false, "when true, fail if any package is unknown")
+	// nolint:errcheck
 	cmd.Flags().MarkHidden("strict")
 
 	return cmd

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func cli() *cobra.Command {
 	var mappingsFile string
 	var updateFlag bool
 	var noBuiltInFlag bool
+	var strictFlag bool
 
 	// Default log level is info
 	var level = slag.Level(slog.LevelInfo)
@@ -128,6 +129,7 @@ func cli() *cobra.Command {
 				Registry:     registry,
 				Update:       updateFlag,
 				NoBuiltIn:    noBuiltInFlag,
+				Strict:       strictFlag,
 			}
 
 			// If custom mappings file is provided, load it as ExtraMappings
@@ -215,6 +217,8 @@ func cli() *cobra.Command {
 	cmd.Flags().BoolVar(&updateFlag, "update", false, "check for and apply available updates")
 	cmd.Flags().BoolVar(&noBuiltInFlag, "no-builtin", false, "skip built-in package/image mappings, still apply default conversion logic")
 	cmd.Flags().Var(&level, "log-level", "log level (e.g. debug, info, warn, error)")
+	cmd.Flags().BoolVar(&strictFlag, "strict", false, "when true, fail if any package is unknown")
+	cmd.Flags().MarkHidden("strict")
 
 	return cmd
 }

--- a/pkg/dfc/dfc.go
+++ b/pkg/dfc/dfc.go
@@ -480,9 +480,6 @@ func parseImageReference(imageRef string) (base, tag string) {
 
 // Convert applies the conversion to the Dockerfile and returns a new converted Dockerfile
 func (d *Dockerfile) Convert(ctx context.Context, opts Options) (*Dockerfile, error) {
-	// if opts.Strict {
-	// 	return nil, fmt.Errorf("todo Eliza :)")
-	// }
 	// Initialize mappings
 	var mappings MappingsConfig
 

--- a/pkg/dfc/dfc_test.go
+++ b/pkg/dfc/dfc_test.go
@@ -1932,3 +1932,39 @@ RUN apt-get update && apt-get install -y nano`
 		t.Errorf("Expected error from RunLineConverter to be propagated, got: %v", err)
 	}
 }
+func TestStrictMode(t *testing.T) {
+	convertTests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{
+			name:    "does not have mapping",
+			raw:     "RUN apt-get install -y saesidon",
+			wantErr: true,
+		},
+		{
+			name:    "has mapping",
+			raw:     "RUN apt-get install -y awscli",
+			wantErr: false,
+		},
+	}
+	for _, tt := range convertTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.Background()
+			parsed, err := ParseDockerfile(ctx, []byte(tt.raw))
+			if err != nil {
+				t.Fatalf("Failed to parse Dockerfile: %v", err)
+			}
+
+			_, convertErr := parsed.Convert(ctx, Options{
+				Strict: true,
+			})
+			gotErr := convertErr != nil
+			if gotErr != tt.wantErr {
+				t.Errorf("%s: wanted %t got %t", tt.name, tt.wantErr, gotErr)
+			}
+		})
+	}
+}

--- a/pkg/dfc/dfc_test.go
+++ b/pkg/dfc/dfc_test.go
@@ -1952,7 +1952,6 @@ func TestStrictMode(t *testing.T) {
 	}
 	for _, tt := range convertTests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			ctx := context.Background()
 			parsed, err := ParseDockerfile(ctx, []byte(tt.raw))
 			if err != nil {


### PR DESCRIPTION
Flag is still hidden because right now this flag will usually cause failure until the mappings are more robust.
#43 