### PR TITLE
Get version and revision using runtime/debug

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,4 @@ jobs:
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
       run: |
         set -x
-        VERSION="${GITHUB_REF#refs/tags/}"
-        REVISION="$(git rev-parse HEAD)"
-        export LDFLAGS="-X main.Version=$VERSION -X main.Revision=$REVISION"
         goreleaser release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,6 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   ldflags:
     - -extldflags "-static"
-    - "{{ .Env.LDFLAGS }}"
 
 signs:
   - id: dfc-cosign

--- a/main.go
+++ b/main.go
@@ -24,14 +24,6 @@ import (
 	"github.com/chainguard-dev/dfc/pkg/dfc"
 )
 
-var (
-	// Version is the semantic version (added at compile time via -X main.Version=$VERSION)
-	Version string
-
-	// Revision is the git commit id (added at compile time via -X main.Revision=$REVISION)
-	Revision string
-)
-
 func main() {
 	ctx := context.Background()
 	if err := mainE(ctx); err != nil {
@@ -59,19 +51,11 @@ func cli() *cobra.Command {
 	// Default log level is info
 	var level = slag.Level(slog.LevelInfo)
 
-	v := "dev"
-	if Version != "" {
-		v = Version
-		if Revision != "" {
-			v += fmt.Sprintf(" (%s)", Revision)
-		}
-	}
-
 	cmd := &cobra.Command{
 		Use:     "dfc",
 		Example: "dfc <path_to_dockerfile>",
 		Args:    cobra.MaximumNArgs(1),
-		Version: v,
+		Version: dfc.Version(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Setup logging
 			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: &level})))
@@ -83,10 +67,8 @@ func cli() *cobra.Command {
 				// Set up update options
 				updateOpts := dfc.UpdateOptions{}
 
-				// Set UserAgent if version info is available
-				if Version != "" {
-					updateOpts.UserAgent = "dfc/" + Version
-				}
+				// Set UserAgent
+				updateOpts.UserAgent = fmt.Sprintf("dfc/%s", dfc.Version())
 
 				if err := dfc.Update(ctx, updateOpts); err != nil {
 					return fmt.Errorf("failed to update: %w", err)

--- a/pkg/dfc/update.go
+++ b/pkg/dfc/update.go
@@ -233,6 +233,7 @@ func Update(ctx context.Context, opts UpdateOptions) error {
 	if userAgent == "" {
 		userAgent = "dfc/dev"
 	}
+	log.Debug("Using user agent", "user_agent", userAgent)
 	req.Header.Set("User-Agent", userAgent)
 
 	// Send the request

--- a/pkg/dfc/version.go
+++ b/pkg/dfc/version.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dfc
+
+import (
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
+var (
+	once        sync.Once
+	dfcVersion  = "dev"
+	dfcRevision = ""
+)
+
+func Version() string {
+	once.Do(func() {
+		bi, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+
+		// Get the main module version
+		if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+			dfcVersion = bi.Main.Version
+		}
+
+		// Get the vcs revision from build settings
+		for _, setting := range bi.Settings {
+			if setting.Key == "vcs.revision" {
+				dfcRevision = setting.Value
+				break
+			}
+		}
+	})
+
+	if dfcRevision != "" {
+		return fmt.Sprintf("%s (%s)", dfcVersion, dfcRevision)
+	}
+	return dfcVersion
+}


### PR DESCRIPTION
Without this, the version is empty when installing dfc via `go install ...`