### PR TITLE
Add dist/ to gitignore to fix version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ coverage.*
 .idea
 .DS_Store
 mcp-server/mcp-server
+
+# Prevent GoReleaser causing a +dirty suffix on --version
+./dist


### PR DESCRIPTION
Possible fix for `+dirty` suffix on version according to https://goreleaser.com/errors/dirty/