### PR TITLE
fix(ci): correct goreleaser-action version pin comment (v2.8.1 -> v6.2.1)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
 
-    - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v2.8.1
+    - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
       with:
         install-only: true
 


### PR DESCRIPTION
# Correct goreleaser-action version pin comment

**Refs:** PSEC-923

Follow-up to the GitHub Actions hardening PR. The `goreleaser/goreleaser-action`
step in `release.yaml` is pinned to commit
`90a3faa9d0182683851fbfa97ca1a2cb983bfca3`, which resolves to **v6.2.1**
(verified against the upstream tags), but the trailing comment claimed
`# v2.8.1` — understating the action by four major versions.

This corrects the comment to `# v6.2.1`. The pinned SHA is unchanged, so CI
behavior is unchanged; this is a provenance-accuracy fix so the comment no
longer misrepresents which version is actually running.
